### PR TITLE
Remove `//go:build linux` tag

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (

--- a/command.go
+++ b/command.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (

--- a/limit.go
+++ b/limit.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (

--- a/project.go
+++ b/project.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (

--- a/report.go
+++ b/report.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (

--- a/report_test.go
+++ b/report_test.go
@@ -54,8 +54,8 @@ func TestCommand_ReportWithId(t *testing.T) {
 #100                12       1024      20480     05 [--------]
 #200                 0          4      10240     00 [--------]`)
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs,Out:          out,}
-      cmd := NewCommand(bin, tt.newCommandArgs.filesystemPath, tt.newCommandArgs.globalOpt)
+			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs, Out: out}
+			cmd := NewCommand(bin, tt.newCommandArgs.filesystemPath, tt.newCommandArgs.globalOpt)
 
 			_, err := cmd.Report(tt.args.ctx, tt.args.quotaType, tt.args.quotaTargetType, tt.args.opt)
 

--- a/values.go
+++ b/values.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 type QuotaType string

--- a/xfs_quota.go
+++ b/xfs_quota.go
@@ -1,4 +1,3 @@
-//go:build linux
 package xfsquota
 
 import (


### PR DESCRIPTION
Because go-xfsquota is a wrapper of command.