### PR TITLE
fix CheckProjectWithId method

### DIFF
--- a/project.go
+++ b/project.go
@@ -99,7 +99,7 @@ func (c *Command) ClearProjectWithId(ctx context.Context, id uint32, opt Project
 }
 
 func (c *Command) CheckProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error {
-	err := c.OperateProjectWithId(ctx, ProjectClearOps, id, opt)
+	err := c.OperateProjectWithId(ctx, ProjectCheckOps, id, opt)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
bugfix;
`ProjectCheckOps` should execute with the `-c` flag that check project tree, but it used `-C` flag actually.