### PR TITLE
Return implementation, not interface.

### DIFF
--- a/xfs_quota.go
+++ b/xfs_quota.go
@@ -98,6 +98,6 @@ func (c *Client) validateBinary() error {
 	return nil
 }
 
-func (c *Client) Command(filesystemPath string, opt *GlobalOption) Commander {
+func (c *Client) Command(filesystemPath string, opt *GlobalOption) *Command {
 	return NewCommand(c.Binary, filesystemPath, opt)
 }


### PR DESCRIPTION
> A great rule of thumb for Go is accept interfaces, return structs. Accepting interfaces gives your API the greatest flexibility and returning structs allows the people reading your code to quickly navigate to the correct function.

ref: https://medium.com/@cep21/preemptive-interface-anti-pattern-in-go-54c18ac0668a
ref: https://github.com/golang/go/wiki/CodeReviewComments#interfaces