### PR TITLE
Rename methods for directory tree ops

### DIFF
--- a/command.go
+++ b/command.go
@@ -24,7 +24,7 @@ type Command struct {
 
 type Commander interface {
 	Execute(ctx context.Context) error
-	OperateProjectWithId(ctx context.Context, op ProjectOpsType, id uint32, opt ProjectCommandOption) error
+	OperateDirectoryTree(ctx context.Context, op ProjectOpsType, id uint32, opt ProjectCommandOption) error
 
 	LimitCommander
 	ReportCommander

--- a/project.go
+++ b/project.go
@@ -10,9 +10,15 @@ import (
 )
 
 type ProjectCommander interface {
-	SetupProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error
-	ClearProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error
-	CheckProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error
+	// SetupDirectoryTree setup directory tree to project identified by projid.
+	// Equeal to "project" subcommand with "-s" flag
+	SetupDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error
+	// ClearDirectoryTree clear directory tree to project identified by projid.
+	// Equeal to "project" subcommand with "-C" flag
+	ClearDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error
+	// CheckDirectoryTree check directory tree to project identified by projid.
+	// Equeal to "project" subcommand with "-c" flag
+	CheckDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error
 }
 
 type projectCommandArgs struct {
@@ -39,15 +45,16 @@ type ProjectCommandOption struct {
 type ProjectOpsType string
 
 const (
-	ProjectSetupOps = ProjectOpsType("Setup")
-	ProjectClearOps = ProjectOpsType("Clear")
-	ProjectCheckOps = ProjectOpsType("Check")
+	ProjectDirTreeSetupOps = ProjectOpsType("Setup")
+	ProjectDirTreeClearOps = ProjectOpsType("Clear")
+	ProjectDirTreeCheckOps = ProjectOpsType("Check")
 )
 
 // Build 'project' subcommand
 //
 // format:
-//   project [ -cCs [ -d depth ] [ -p path ] id | name ]
+//
+//	project [ -cCs [ -d depth ] [ -p path ] id | name ]
 func (o projectCommandArgs) buildArgs() []string {
 	args := []string{}
 	args = append(args, "project")
@@ -63,11 +70,11 @@ func (o projectCommandArgs) buildArgs() []string {
 	}
 
 	switch o.operation {
-	case ProjectSetupOps:
+	case ProjectDirTreeSetupOps:
 		args = append(args, "-s")
-	case ProjectClearOps:
+	case ProjectDirTreeClearOps:
 		args = append(args, "-C")
-	case ProjectCheckOps:
+	case ProjectDirTreeCheckOps:
 		args = append(args, "-c")
 	}
 
@@ -80,7 +87,7 @@ func (o projectCommandArgs) buildArgs() []string {
 	return args
 }
 
-func (c *Command) OperateProjectWithId(ctx context.Context, op ProjectOpsType, id uint32, opt ProjectCommandOption) error {
+func (c *Command) OperateDirectoryTree(ctx context.Context, op ProjectOpsType, id uint32, opt ProjectCommandOption) error {
 	c.GlobalOpt.EnableExpertMode = true // require expert mode
 	c.subCmdArgs = &projectCommandArgs{
 		id:        []uint32{id},
@@ -90,16 +97,16 @@ func (c *Command) OperateProjectWithId(ctx context.Context, op ProjectOpsType, i
 	return c.Execute(ctx)
 }
 
-func (c *Command) SetupProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error {
-	return c.OperateProjectWithId(ctx, ProjectSetupOps, id, opt)
+func (c *Command) SetupDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error {
+	return c.OperateDirectoryTree(ctx, ProjectDirTreeSetupOps, projid, opt)
 }
 
-func (c *Command) ClearProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error {
-	return c.OperateProjectWithId(ctx, ProjectClearOps, id, opt)
+func (c *Command) ClearDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error {
+	return c.OperateDirectoryTree(ctx, ProjectDirTreeClearOps, projid, opt)
 }
 
-func (c *Command) CheckProjectWithId(ctx context.Context, id uint32, opt ProjectCommandOption) error {
-	err := c.OperateProjectWithId(ctx, ProjectCheckOps, id, opt)
+func (c *Command) CheckDirectoryTree(ctx context.Context, projid uint32, opt ProjectCommandOption) error {
+	err := c.OperateDirectoryTree(ctx, ProjectDirTreeCheckOps, projid, opt)
 	if err != nil {
 		return err
 	}

--- a/project_test.go
+++ b/project_test.go
@@ -5,34 +5,22 @@ import (
 	"testing"
 )
 
-func TestCommand_OperateProjectWithId(t *testing.T) {
+func TestCommand_SetupDirectoryTree(t *testing.T) {
 	type args struct {
-		ctx context.Context
-		op  ProjectOpsType
-		id  uint32
-		opt ProjectCommandOption
-	}
-
-	type newCommandArgs struct {
-		filesystemPath string
-		globalOpt      *GlobalOption
+		ctx    context.Context
+		projid uint32
+		opt    ProjectCommandOption
 	}
 
 	tests := []struct {
-		name           string
-		newCommandArgs newCommandArgs
-		args           args
-		expectErr      bool
-		expectBinArgs  []string
+		name          string
+		args          args
+		expectErr     bool
+		expectBinArgs []string
 	}{
 		{
-			name: "setup project",
-			newCommandArgs: newCommandArgs{
-				filesystemPath: "/xfs_root",
-			},
 			args: args{
-				op: ProjectSetupOps,
-				id: 100,
+				projid: 100,
 				opt: ProjectCommandOption{
 					Depth: 5,
 					Path:  "/xfs_root/dir",
@@ -41,14 +29,43 @@ func TestCommand_OperateProjectWithId(t *testing.T) {
 			expectErr:     false,
 			expectBinArgs: []string{"-x", "-c", "project -d 5 -p /xfs_root/dir -s 100", "/xfs_root"},
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.ctx == nil {
+				tt.args.ctx = context.Background() // Default
+			}
+
+			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
+
+			err := cmd.SetupDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Unexpected error :%v", err)
+			}
+
+			bin.AssertArgs(t)
+		})
+	}
+}
+
+func TestCommand_ClearDirectoryTree(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		projid uint32
+		opt    ProjectCommandOption
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectErr     bool
+		expectBinArgs []string
+	}{
 		{
-			name: "clear project",
-			newCommandArgs: newCommandArgs{
-				filesystemPath: "/xfs_root",
-			},
 			args: args{
-				op: ProjectClearOps,
-				id: 100,
+				projid: 100,
 				opt: ProjectCommandOption{
 					Depth: 5,
 					Path:  "/xfs_root/dir",
@@ -66,10 +83,54 @@ func TestCommand_OperateProjectWithId(t *testing.T) {
 			}
 
 			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
-			cmd := NewCommand(bin, tt.newCommandArgs.filesystemPath, tt.newCommandArgs.globalOpt)
+			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
 
-			err := cmd.OperateProjectWithId(tt.args.ctx, tt.args.op, tt.args.id, tt.args.opt)
+			err := cmd.ClearDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("Unexpected error :%v", err)
+			}
 
+			bin.AssertArgs(t)
+		})
+	}
+}
+
+func TestCommand_CheckDirectoryTree(t *testing.T) {
+	type args struct {
+		ctx    context.Context
+		projid uint32
+		opt    ProjectCommandOption
+	}
+
+	tests := []struct {
+		name          string
+		args          args
+		expectErr     bool
+		expectBinArgs []string
+	}{
+		{
+			args: args{
+				projid: 100,
+				opt: ProjectCommandOption{
+					Depth: 5,
+					Path:  "/xfs_root/dir",
+				},
+			},
+			expectErr:     false,
+			expectBinArgs: []string{"-x", "-c", "project -d 5 -p /xfs_root/dir -c 100", "/xfs_root"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.args.ctx == nil {
+				tt.args.ctx = context.Background() // Default
+			}
+
+			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
+
+			err := cmd.CheckDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)
 			if (err != nil) != tt.expectErr {
 				t.Errorf("Unexpected error :%v", err)
 			}

--- a/testutil/cmd/integration_test.go
+++ b/testutil/cmd/integration_test.go
@@ -43,7 +43,7 @@ func TestProject(t *testing.T) {
 				filesystemPath: "/xfs_root",
 			},
 			args: args{
-				op: xfsquota.ProjectSetupOps,
+				op: xfsquota.ProjectDirTreeSetupOps,
 				id: 100,
 				opt: xfsquota.ProjectCommandOption{
 					Depth: 5,
@@ -69,7 +69,7 @@ func TestProject(t *testing.T) {
 				filesystemPath: "/xfs_root",
 			},
 			args: args{
-				op: xfsquota.ProjectClearOps,
+				op: xfsquota.ProjectDirTreeClearOps,
 				id: 100,
 				opt: xfsquota.ProjectCommandOption{
 					Depth: 5,
@@ -94,7 +94,7 @@ func TestProject(t *testing.T) {
 				filesystemPath: "/xfs_root",
 			},
 			args: args{
-				op: xfsquota.ProjectSetupOps,
+				op: xfsquota.ProjectDirTreeSetupOps,
 				id: 100,
 				opt: xfsquota.ProjectCommandOption{
 					Depth: 5,
@@ -120,7 +120,7 @@ func TestProject(t *testing.T) {
 				filesystemPath: "/xfs_root",
 			},
 			args: args{
-				op: xfsquota.ProjectSetupOps,
+				op: xfsquota.ProjectDirTreeSetupOps,
 				id: 101,
 				opt: xfsquota.ProjectCommandOption{
 					Depth: 5,
@@ -158,7 +158,7 @@ func TestProject(t *testing.T) {
 				t.Fatal(err)
 			}
 			c := q.Command(tt.newCommandArgs.filesystemPath, nil)
-			if err := c.OperateProjectWithId(ctx, tt.args.op, tt.args.id, tt.args.opt); err != nil {
+			if err := c.OperateDirectoryTree(ctx, tt.args.op, tt.args.id, tt.args.opt); err != nil {
 				t.Fatal(err)
 			}
 			r, err := c.Report(ctx, xfsquota.QuotaTypeProject, xfsquota.QuotaTargetTypeBlocks, xfsquota.ReportCommandOption{})

--- a/testutil/cmd/project.go
+++ b/testutil/cmd/project.go
@@ -43,17 +43,17 @@ func cmdProject(w io.Writer, args []string, mountPath string) error {
 			continue
 		case a == "-s":
 			// setup
-			ptype = xfsquota.ProjectSetupOps
+			ptype = xfsquota.ProjectDirTreeSetupOps
 			i++
 			continue
 		case a == "-C":
 			// clear
-			ptype = xfsquota.ProjectClearOps
+			ptype = xfsquota.ProjectDirTreeClearOps
 			i++
 			continue
 		case a == "-c":
 			// check
-			ptype = xfsquota.ProjectCheckOps
+			ptype = xfsquota.ProjectDirTreeCheckOps
 			i++
 			continue
 		case strings.HasPrefix(a, "-"):
@@ -80,15 +80,15 @@ func cmdProject(w io.Writer, args []string, mountPath string) error {
 		proj = Project{ID: id}
 	}
 	switch ptype {
-	case xfsquota.ProjectSetupOps:
+	case xfsquota.ProjectDirTreeSetupOps:
 		if !slices.Contains(proj.Paths, path) {
 			proj.Paths = append(proj.Paths, path)
 		}
-	case xfsquota.ProjectClearOps:
+	case xfsquota.ProjectDirTreeClearOps:
 		proj.Paths = slices.DeleteFunc(proj.Paths, func(p string) bool {
 			return p == path
 		})
-	case xfsquota.ProjectCheckOps:
+	case xfsquota.ProjectDirTreeCheckOps:
 	}
 	if len(proj.Paths) == 0 && proj.Bhard == 0 && proj.Bsoft == 0 && proj.Ihard == 0 && proj.Isoft == 0 {
 		delete(q.Projects, id)


### PR DESCRIPTION
Rename methods of `ProjectCommander` because they operate directory tree rather than project.