### PR TITLE
Revert "Return implementation, not interface."

### DIFF
--- a/xfs_quota.go
+++ b/xfs_quota.go
@@ -92,6 +92,6 @@ func (c *Client) validateBinary() error {
 	return nil
 }
 
-func (c *Client) Command(filesystemPath string, opt *GlobalOption) *Command {
+func (c *Client) Command(filesystemPath string, opt *GlobalOption) Commander {
 	return NewCommand(c.Binary, filesystemPath, opt)
 }


### PR DESCRIPTION
Reverts ry023/go-xfsquota#12

Because Go-xfsquota uses method chaining, it is not possible to define an interface that replaces the client when testing with the client.