### PR TITLE
Unexport vars/structs that are exported unnecessarily

### DIFF
--- a/binary_mock_test.go
+++ b/binary_mock_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-type MockBinary struct {
+type mockBinary struct {
 	ExpectedArgs []string
 	ActualArgs   []string
 	Out          []byte
 }
 
-func (m *MockBinary) Execute(ctx context.Context, stdout io.Writer, stderr io.Writer, args ...string) error {
+func (m *mockBinary) Execute(ctx context.Context, stdout io.Writer, stderr io.Writer, args ...string) error {
 	m.ActualArgs = args
 
 	if len(m.Out) > 0 {
@@ -24,11 +24,11 @@ func (m *MockBinary) Execute(ctx context.Context, stdout io.Writer, stderr io.Wr
 	return nil
 }
 
-func (m *MockBinary) Validate() error {
+func (m *mockBinary) Validate() error {
 	return nil
 }
 
-func (m *MockBinary) AssertArgs(t *testing.T) {
+func (m *mockBinary) AssertArgs(t *testing.T) {
 	if diff := cmp.Diff(m.ExpectedArgs, m.ActualArgs); diff != "" {
 		t.Errorf("Args on mary exception not match!\n%v`", diff)
 	}

--- a/limit_test.go
+++ b/limit_test.go
@@ -46,7 +46,7 @@ func TestCommand_LimitWithId(t *testing.T) {
 				tt.args.ctx = context.Background() // Default
 			}
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			bin := &mockBinary{ExpectedArgs: tt.expectBinArgs}
 			cmd := NewCommand(bin, tt.newCommandArgs.filesystemPath, tt.newCommandArgs.globalOpt)
 
 			err := cmd.LimitWithId(tt.args.ctx, tt.args.id, tt.args.quotaType, tt.args.opt)

--- a/project.go
+++ b/project.go
@@ -119,8 +119,6 @@ func (c *Command) CheckDirectoryTree(ctx context.Context, projid uint32, opt Pro
 	return c.checkOutput(b)
 }
 
-var projectCheckRegexp = regexp.MustCompile(`^(.*) - project inheritance flag is not set`)
-
 type ProjectCheckError struct {
 	Errors []error
 }

--- a/project.go
+++ b/project.go
@@ -119,7 +119,7 @@ func (c *Command) CheckDirectoryTree(ctx context.Context, projid uint32, opt Pro
 	return c.checkOutput(b)
 }
 
-var ProjectCheckRegexp = regexp.MustCompile(`^(.*) - project inheritance flag is not set`)
+var projectCheckRegexp = regexp.MustCompile(`^(.*) - project inheritance flag is not set`)
 
 type ProjectCheckError struct {
 	Errors []error
@@ -133,7 +133,7 @@ func (e *ProjectCheckError) Error() string {
 	}
 }
 
-var ProjectIdNotSetRegexp = regexp.MustCompile(`^(.*) - project identifier is not set`)
+var projectIdNotSetRegexp = regexp.MustCompile(`^(.*) - project identifier is not set`)
 
 type ProjectIdNotSetError struct {
 	Directory string
@@ -143,7 +143,7 @@ func (e *ProjectIdNotSetError) Error() string {
 	return fmt.Sprintf("Project identifier is not set on directory (%s)", e.Directory)
 }
 
-var ProjectInheritanceFlagNotSetRegexp = regexp.MustCompile(`^(.*) - project inheritance flag is not set`)
+var projectInheritanceFlagNotSetRegexp = regexp.MustCompile(`^(.*) - project inheritance flag is not set`)
 
 type ProjectInheritanceFlagNotSetError struct {
 	Directory string
@@ -158,12 +158,12 @@ func (c *Command) checkOutput(b []byte) error {
 	lines := strings.Split(string(b), "\n")
 	for _, l := range lines {
 		var submatches []string
-		submatches = ProjectIdNotSetRegexp.FindStringSubmatch(l)
+		submatches = projectIdNotSetRegexp.FindStringSubmatch(l)
 		if len(submatches) == 2 {
 			errs = append(errs, &ProjectIdNotSetError{Directory: submatches[1]})
 		}
 
-		submatches = ProjectInheritanceFlagNotSetRegexp.FindStringSubmatch(l)
+		submatches = projectInheritanceFlagNotSetRegexp.FindStringSubmatch(l)
 		if len(submatches) == 2 {
 			errs = append(errs, &ProjectInheritanceFlagNotSetError{Directory: submatches[1]})
 		}

--- a/project_test.go
+++ b/project_test.go
@@ -37,7 +37,7 @@ func TestCommand_SetupDirectoryTree(t *testing.T) {
 				tt.args.ctx = context.Background() // Default
 			}
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			bin := &mockBinary{ExpectedArgs: tt.expectBinArgs}
 			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
 
 			err := cmd.SetupDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)
@@ -82,7 +82,7 @@ func TestCommand_ClearDirectoryTree(t *testing.T) {
 				tt.args.ctx = context.Background() // Default
 			}
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			bin := &mockBinary{ExpectedArgs: tt.expectBinArgs}
 			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
 
 			err := cmd.ClearDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)
@@ -127,7 +127,7 @@ func TestCommand_CheckDirectoryTree(t *testing.T) {
 				tt.args.ctx = context.Background() // Default
 			}
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs}
+			bin := &mockBinary{ExpectedArgs: tt.expectBinArgs}
 			cmd := NewCommand(bin, "/xfs_root", &GlobalOption{})
 
 			err := cmd.CheckDirectoryTree(tt.args.ctx, tt.args.projid, tt.args.opt)

--- a/report_test.go
+++ b/report_test.go
@@ -54,7 +54,7 @@ func TestCommand_ReportWithId(t *testing.T) {
 #100                12       1024      20480     05 [--------]
 #200                 0          4      10240     00 [--------]`)
 
-			bin := &MockBinary{ExpectedArgs: tt.expectBinArgs, Out: out}
+			bin := &mockBinary{ExpectedArgs: tt.expectBinArgs, Out: out}
 			cmd := NewCommand(bin, tt.newCommandArgs.filesystemPath, tt.newCommandArgs.globalOpt)
 
 			_, err := cmd.Report(tt.args.ctx, tt.args.quotaType, tt.args.quotaTargetType, tt.args.opt)

--- a/xfs_quota.go
+++ b/xfs_quota.go
@@ -22,17 +22,17 @@ type Client struct {
 	VersionCommandRegexp *regexp.Regexp
 }
 
-const DefaultVersionConstraint = ">= 5.13.0"
+const defaultVersionConstraint = ">= 5.13.0"
 
-var DefaultVersionCommandRegexp = regexp.MustCompile(`xfs_quota version\s(.*)\r?\n?$`)
+var defaultVersionCommandRegexp = regexp.MustCompile(`xfs_quota version\s(.*)\r?\n?$`)
 
 func New(binaryPath string) (*Client, error) {
 	c := &Client{
 		Binary: &Binary{
 			Path: binaryPath,
 		},
-		VersionConstraint:    DefaultVersionConstraint,
-		VersionCommandRegexp: DefaultVersionCommandRegexp,
+		VersionConstraint:    defaultVersionConstraint,
+		VersionCommandRegexp: defaultVersionCommandRegexp,
 	}
 
 	if err := c.validateBinary(); err != nil {


### PR DESCRIPTION
Unexport vars/structs that are exported unnecessarily.